### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scripts/autosumpdf.py
+++ b/scripts/autosumpdf.py
@@ -145,7 +145,7 @@ def search_citation(text, exp):
     text = ' '.join(lines)
     text = ' '.join(text.split())
     text = ftfy.fix_text(text.decode())
-    logging.info("Search...'%s'" % exp)
+    logging.info("Search...'{0!s}'".format(exp))
     sentences, st_index = split_sentences(text)
     regex = citation_regex()
     founds = set()
@@ -170,10 +170,10 @@ if __name__ == "__main__":
     output = []
 
     if not os.path.exists(args.txt_dir):
-        logging.info("Create text files directory... (%s)" % args.txt_dir)
+        logging.info("Create text files directory... ({0!s})".format(args.txt_dir))
         os.makedirs(args.txt_dir)
     else:
-        logging.info("Current text files directory... (%s)" % args.txt_dir)
+        logging.info("Current text files directory... ({0!s})".format(args.txt_dir))
 
     with open(args.input, 'rb') as f:
         reader = csv.DictReader(f)
@@ -182,13 +182,13 @@ if __name__ == "__main__":
             i += 1
             pdf_path = r['pdf_path']
             try:
-                txtfile = os.path.join(args.txt_dir, "%d.txt" % i)
+                txtfile = os.path.join(args.txt_dir, "{0:d}.txt".format(i))
                 if not args.force and os.path.exists(txtfile):
-                    logging.info("Use exists text file...'%s'" % txtfile)
+                    logging.info("Use exists text file...'{0!s}'".format(txtfile))
                     with open(txtfile, 'rb') as f:
                         text = f.read()
                 else:
-                    logging.info("Extract text from PDF...'%s'" % pdf_path)
+                    logging.info("Extract text from PDF...'{0!s}'".format(pdf_path))
                     text = convert_pdf_to_txt(pdf_path)
                     with open(txtfile, 'wb') as f:
                         f.write(text)
@@ -196,7 +196,7 @@ if __name__ == "__main__":
                 for e in args.regex:
                     results = search_citation(text, e)
                     founds.update(results)
-                    logging.info("Regex: '%s', Found: %d" % (e, len(results)))
+                    logging.info("Regex: '{0!s}', Found: {1:d}".format(e, len(results)))
                 r['founds'] = '\n'.join(founds)
                 r['status'] = 'OK'
             except Exception as e:
@@ -205,7 +205,7 @@ if __name__ == "__main__":
                 pass
             output.append(r)
 
-    logging.info("Save output to file...'%s'" % args.output)
+    logging.info("Save output to file...'{0!s}'".format(args.output))
     with open(args.output, 'wb') as f:
         writer = csv.DictWriter(f, fieldnames=['url', 'title', 'authors',
                                 'summary', 'cited_by', 'pdf_url',

--- a/scripts/scholar.py
+++ b/scripts/scholar.py
@@ -165,7 +165,7 @@ class ScholarWebClient(object):
         return os.path.join(TMP_DIR, path)
 
     def query(self, query='', author=''):
-        logging.info("Query...'%s'" % query)
+        logging.info("Query...'{0!s}'".format(query))
         if USE_TMP and os.path.exists(self.tmp_path('query.html')):
             logging.info("Use temporary file...")
             with open(self.tmp_path('query.html'), 'rb') as f:
@@ -178,7 +178,7 @@ class ScholarWebClient(object):
             'as_oq': '',
             'as_eq': '',
             'as_occt': 'any',
-            'as_sauthors': '"%s"' % author,
+            'as_sauthors': '"{0!s}"'.format(author),
             'as_publication': '',
             'as_ylo': '',
             'as_yhi': '',
@@ -187,7 +187,7 @@ class ScholarWebClient(object):
             'as_sdt': '0,5'
         }
         url += '/scholar?' + urlencode(params)
-        logging.debug("Query URL: '%s'" % url)
+        logging.debug("Query URL: '{0!s}'".format(url))
         text = ''
         try:
             response = self.opener.open(url)
@@ -201,12 +201,12 @@ class ScholarWebClient(object):
 
     def download(self, url, path):
         # Download the file from `url` and save it locally under `path`:
-        logging.info("Download URL: '%s'" % url)
+        logging.info("Download URL: '{0!s}'".format(url))
         try:
             response = self.opener.open(url, timeout=30)
             data = response.read()
             with open(path, 'wb') as out_file:
-                logging.info("Save to: '%s" % path)
+                logging.info("Save to: '{0!s}".format(path))
                 out_file.write(data)
         except Exception as e:
             logging.error(e)
@@ -232,21 +232,21 @@ class ScholarWebClient(object):
 
     def browse(self, url='', page=1):
         logging.info("Browse...")
-        if USE_TMP and os.path.exists(self.tmp_path('page-%d.html' % page)):
+        if USE_TMP and os.path.exists(self.tmp_path('page-{0:d}.html'.format(page))):
             logging.info("Use temporary file...")
-            with open(self.tmp_path('page-%d.html' % page), 'rb') as f:
+            with open(self.tmp_path('page-{0:d}.html'.format(page)), 'rb') as f:
                 text = f.read()
             return text
         url = GOOGLE_SCHOLAR_URL + url
         if page > 1:
-            url += ('&start=%d' % ((page - 1)*10))
-        logging.debug("Browse URL: '%s'" % url)
+            url += ('&start={0:d}'.format(((page - 1)*10)))
+        logging.debug("Browse URL: '{0!s}'".format(url))
         text = ''
         try:
             response = self.opener.open(url)
             text = response.read()
             if self.args.verbose:
-                with open(self.tmp_path('page-%d.html' % page), 'wb') as f:
+                with open(self.tmp_path('page-{0:d}.html'.format(page)), 'wb') as f:
                     f.write(text)
         except Exception as e:
             logging.error(e)
@@ -259,7 +259,7 @@ class ScholarWebClient(object):
         cites = []
         for r in rows:
             i += 1
-            logging.info("No: %d" % i)
+            logging.info("No: {0:d}".format(i))
             title = r.find('h3', class_='gs_rt')
             if title:
                 if title.a:
@@ -320,7 +320,7 @@ def test_pdf():
         try:
             pdf = pdfquery.PDFQuery(f)
             pdf.load()
-            pdf.tree.write("%s.xml" % bn, pretty_print=True, encoding="utf-8")
+            pdf.tree.write("{0!s}.xml".format(bn), pretty_print=True, encoding="utf-8")
         except Exception as e:
             print e
             print "ERROR"
@@ -360,7 +360,7 @@ if __name__ == "__main__":
     else:
         setup_logger(logging.INFO)
     args.keywords = ' '.join(args.keyword)
-    logging.debug("keywords = '%s'" % args.keywords)
+    logging.debug("keywords = '{0!s}'".format(args.keywords))
     session = ScholarWebClient(args)
     signed_in = session.start()
     if not signed_in:
@@ -384,14 +384,14 @@ if __name__ == "__main__":
         logging.error("Google detected, we're a robot.")
 
     url, count = session.get_cited_by_url(html)
-    logging.info("Total cited by %d" % count)
+    logging.info("Total cited by {0:d}".format(count))
     n_cites = min(args.n_cites, count)
     all_cites = []
     page = 0
     n_pages = (n_cites - 1)/10 + 1
     while page < n_pages:
         page += 1
-        logging.debug("Page = %d" % page)
+        logging.debug("Page = {0:d}".format(page))
         html = session.browse(url, page)
         if session.is_robot_detected(html):
             logging.error("Google detected, we're a robot.")
@@ -407,12 +407,12 @@ if __name__ == "__main__":
     for n, c in enumerate(all_cites):
         pdf_url = c['pdf_url']
         if pdf_url != '':
-            path = os.path.join(args.dir, '%d.pdf' % (n + 1))
+            path = os.path.join(args.dir, '{0:d}.pdf'.format((n + 1)))
             c['pdf_path'] = path
             if os.path.exists(path):
-                logging.info("Skip, '%s' exists" % path)
+                logging.info("Skip, '{0!s}' exists".format(path))
             else:
-                logging.info("Download...'%s'" % path)
+                logging.info("Download...'{0!s}'".format(path))
                 # Download PDF files
                 session.download(pdf_url, path)
 

--- a/scripts/searchpdf.py
+++ b/scripts/searchpdf.py
@@ -90,7 +90,7 @@ def search_regex(text, exp):
     # join multiple lines
     lines = text.split('\n')
     text = ' '.join(lines)
-    logging.info("Search...'%s'" % exp)
+    logging.info("Search...'{0!s}'".format(exp))
     regex = re.compile(exp, flags=(re.I))
     founds = []
     for m in regex.finditer(text):
@@ -116,13 +116,13 @@ if __name__ == "__main__":
             i += 1
             pdf_path = r['pdf_path']
             try:
-                txtfile = os.path.join(TMP_DIR, "%d.txt" % i)
+                txtfile = os.path.join(TMP_DIR, "{0:d}.txt".format(i))
                 if USE_TMP and os.path.exists(txtfile):
-                    logging.info("Use temporary...'%s'" % txtfile)
+                    logging.info("Use temporary...'{0!s}'".format(txtfile))
                     with open(txtfile, 'rb') as f:
                         text = f.read()
                 else:
-                    logging.info("Extract text...'%s'" % pdf_path)
+                    logging.info("Extract text...'{0!s}'".format(pdf_path))
                     text = convert_pdf_to_txt(pdf_path)
                     with open(txtfile, 'wb') as f:
                         f.write(text)
@@ -137,7 +137,7 @@ if __name__ == "__main__":
                 pass
             output.append(r)
 
-    logging.info("Save output to file...'%s'" % args.output)
+    logging.info("Save output to file...'{0!s}'".format(args.output))
     with open(args.output, 'wb') as f:
         writer = csv.DictWriter(f, fieldnames=['url', 'title', 'authors',
                                 'summary', 'cited_by', 'pdf_url',


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:autosum?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:autosum?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
